### PR TITLE
Linux directory fix

### DIFF
--- a/extensions/libprocinfo/libprocinfo.yy
+++ b/extensions/libprocinfo/libprocinfo.yy
@@ -150,7 +150,7 @@
   "tvosThirdPartyFrameworkEntries": [],
   "IncludedResources": [],
   "androidPermissions": [],
-  "copyToTargets": 202375362,
+  "copyToTargets": 66,
   "parent": {
     "name": "Extensions",
     "path": "folders/Extensions.yy",

--- a/scripts/vsws_core_find_file/vsws_core_find_file.gml
+++ b/scripts/vsws_core_find_file/vsws_core_find_file.gml
@@ -1,26 +1,27 @@
 function vsws_core_find_file()
 {
+	
 		   //If the GET is empty (ie, www.example.com/ ) the server selects the file to look for as the default home file (by default, this is index.html - the existence of a index.php with PHP enabled supersedes this)
 			if (file_get_final == "")
 			{
-				file_get_replace = ""
+				file_get_replace = directory+file_get+"index.html" //Fallback setting to prevent issues on Linux
 				
 				if (file_exists(directory+file_get+"index.html"))
 				{
-					file_get_replace = "/"+file_get+"index.html";
+					file_get_replace = file_get+"index.html";
 				}
 				if (file_exists(directory+file_get+"index.php") && php_enabled == true)
 				{
-					file_get_replace = "/"+file_get+"index.php";
+					file_get_replace = file_get+"index.php";
 				}
 				
 				file_get = file_get_replace;
 			}
 			
 			//Checks to see if the file that's being looked for is loaded into the server
-			if (file_exists(directory+"/"+file_get))
+			if (file_exists(directory+file_get))
 			{
-				file_get = directory+"/"+file_get//If it is found, the correct path to read from is designated.
+				file_get = directory+file_get//If it is found, the correct path to read from is designated.
 				status_code = 200; //And status code 200 is returned for OK.
 			}
 			else


### PR DESCRIPTION
GameMaker was finding directories that didn't exist and claiming they were valid files - which VSWS would then try to load into a buffer, causing a segmentation fault.

We can't change how GM operates (we can file a bug report and we can write a more robust file_file script) but this simple fix will do for now.

Fixes #2 